### PR TITLE
Read the raw body and the note

### DIFF
--- a/fields.go
+++ b/fields.go
@@ -43,4 +43,6 @@ type Commit struct {
 	Tag       *Tag
 	Subject   string
 	Body      string
+	RawBody   string // Both Subject and Body without stripping any newlines
+	Note      string
 }

--- a/gitlog.go
+++ b/gitlog.go
@@ -15,6 +15,8 @@ const (
 	committerField = "COMMITTER"
 	subjectField   = "SUBJECT"
 	bodyField      = "BODY"
+	rawBodyField   = "RAW_BODY"
+	noteField      = "NOTE"
 	tagField       = "TAG"
 
 	hashFormat      = hashField + ":%H %h"
@@ -23,6 +25,8 @@ const (
 	committerFormat = committerField + ":%cn<%ce>[%ct]"
 	subjectFormat   = subjectField + ":%s"
 	bodyFormat      = bodyField + ":%b"
+	rawBodyFormat   = rawBodyField + ":%B"
+	noteFormat      = noteField + ":%N"
 	tagFormat       = tagField + ":%D"
 
 	separator = "@@__GIT_LOG_SEPARATOR__@@"
@@ -35,7 +39,9 @@ const (
 		committerFormat + delimiter +
 		tagFormat + delimiter +
 		subjectFormat + delimiter +
-		bodyFormat
+		bodyFormat + delimiter +
+		rawBodyFormat + delimiter +
+		noteFormat
 )
 
 // Config for getting git-log

--- a/gitlog_test.go
+++ b/gitlog_test.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
+	assertlib "github.com/stretchr/testify/assert"
 )
 
 func rimraf(dir string) {
@@ -82,7 +82,7 @@ func setup() func() {
 }
 
 func TestNewGitLog(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	assert.NotPanics(func() {
 		New(nil)
@@ -106,10 +106,10 @@ func TestNewGitLog(t *testing.T) {
 }
 
 func TestGitLog(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
-	clear := setup()
-	defer clear()
+	clearCallback := setup()
+	defer clearCallback()
 
 	git := New(&Config{
 		Path: ".tmp",
@@ -149,7 +149,7 @@ func TestGitLog(t *testing.T) {
 }
 
 func TestGitLogNumber(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()
@@ -174,7 +174,7 @@ func TestGitLogNumber(t *testing.T) {
 }
 
 func TestGitLogMergesOnly(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()
@@ -192,7 +192,7 @@ func TestGitLogMergesOnly(t *testing.T) {
 }
 
 func TestGitLogIgnoreMerges(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()
@@ -210,7 +210,7 @@ func TestGitLogIgnoreMerges(t *testing.T) {
 }
 
 func TestGitLogReverse(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()
@@ -241,7 +241,7 @@ func TestGitLogReverse(t *testing.T) {
 // FIXME: Time tests
 
 func TestGitLogNotFoundGitCommand(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()
@@ -258,7 +258,7 @@ func TestGitLogNotFoundGitCommand(t *testing.T) {
 }
 
 func TestGitLogNotFoundPath(t *testing.T) {
-	assert := assert.New(t)
+	assert := assertlib.New(t)
 
 	clear := setup()
 	defer clear()

--- a/parser.go
+++ b/parser.go
@@ -50,6 +50,10 @@ func (p *parser) parseCommit(str *string) *Commit {
 			commit.Subject = p.parseSubject(&content)
 		case bodyField:
 			commit.Body = p.parseBody(&content)
+		case rawBodyField:
+			commit.RawBody = p.parseRawBody(&content)
+		case noteField:
+			commit.Note = p.parseNote(&content)
 		}
 	}
 
@@ -142,4 +146,12 @@ func (p *parser) parseBody(str *string) string {
 	s = strings.Trim(s, "\"")
 	s = strings.TrimSpace(s)
 	return s
+}
+
+func (p *parser) parseRawBody(str *string) string {
+	return p.parseBody(str)
+}
+
+func (p *parser) parseNote(str *string) string {
+	return p.parseBody(str)
 }


### PR DESCRIPTION
## Why

### Raw Body

While working on https://github.com/Goutte/git-spend I had a bunch of commit messages written by non-tech collaborators like so :

```
style: rework the margins
/spend 1h
```

Since there's no empty line to mark the distinction between subject and body, both lines end up in the Subject, but the newline is replaced by a space.

> `style: rework the margins /spend 1h`

I want to keep the requirement that the `/spend` directive ought to be at the beginning of a line, so I need to read from the Raw Body.

### Notes

> A typical use of notes is to supplement a commit message without changing the commit itself.  [source](https://git-scm.com/docs/git-notes)

I might use them as well eventually for `/spend` directives, depending on how they blend with software forges (like Gitea).

## No Tests :warning: 

I spent more time trying to run the tests (unsuccessfully) than I did writing the feature.  So there are no tests attached, but I am using this branch successfully in `git-spend`.

